### PR TITLE
load only model config without weights when using quantization

### DIFF
--- a/santacoder_inference.py
+++ b/santacoder_inference.py
@@ -34,7 +34,7 @@ def get_santacoder(model, checkpoint, wbits, groupsize):
     else:
         # Load only models without weights
         config = AutoConfig.from_pretrained(model)
-        model =  AutoModelForCausalLM.from_config(config)
+        model =  AutoModelForCausalLM.from_config(config, torch_dtype=torch_dtype)
     model = model.eval()
 
     if wbits < 16:

--- a/santacoder_inference.py
+++ b/santacoder_inference.py
@@ -5,6 +5,7 @@ import termcolor
 import torch
 import transformers
 from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig
 
 from gptq import *
 from modelutils import *
@@ -27,7 +28,13 @@ def get_santacoder(model, checkpoint, wbits, groupsize):
     else:
         torch_dtype = torch.float32
 
-    model = AutoModelForCausalLM.from_pretrained(model, torch_dtype=torch_dtype)
+    if checkpoint is None:
+        # Load full model with weights
+        model = AutoModelForCausalLM.from_pretrained(model, torch_dtype=torch_dtype)
+    else:
+        # Load only models without weights
+        config = AutoConfig.from_pretrained(model)
+        model =  AutoModelForCausalLM.from_config(config)
     model = model.eval()
 
     if wbits < 16:


### PR DESCRIPTION
When utilizing a quantized checkpoint, the full model weights were previously being downloaded. This issue has been resolved by modifying the loading process to rely solely on the configuration.